### PR TITLE
Implement user search functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple REST API, that enables registered users to ask and get answers to questions, providing access to features like up-voting and down-voting among other things.",
   "main": "index.js",
   "scripts": {
-    "test": "cross-env NODE_ENV=test nyc --reporter=text --reporter=html mocha src/**/*.test.js --timeout 10000 -c -r @babel/register --exit",
+    "test": "cross-env NODE_ENV=test nyc --reporter=text --reporter=html mocha src/**/*.test.js --timeout 12000 -c -r @babel/register --exit",
     "start:dev": "nodemon --exec babel-node src",
     "start": "node dist/",
     "build": "babel src -d dist",

--- a/src/controllers/answer.js
+++ b/src/controllers/answer.js
@@ -43,6 +43,20 @@ class AnswerController {
       errorResponse(res, {});
     }
   }
+
+  /**
+   * Fetches an answer by its Id.
+   *
+   * @static
+   * @param {Request} req - The request from the endpoint.
+   * @param {Response} res - The response returned by the method.
+   * @returns { JSON } A JSON response containing the details of the answer.
+   * @memberof QuestionController
+   */
+  static getAnswerById(req, res) {
+    const { answer } = req;
+    successResponse(res, answer, 200);
+  }
 }
 
 export default AnswerController;

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -23,7 +23,11 @@ class AuthController {
       const user = new User(req.body);
       await user.save();
       const userData = addTokenToRes(user);
-      res.cookie('token', userData.token, { maxAge: 7200000, httpOnly: true });
+      res.cookie('token', userData.token, {
+        maxAge: 7200000,
+        httpOnly: true,
+        sameSite: true
+      });
       return successResponse(res, userData, 201);
     } catch (e) {
       errorResponse(res, {});
@@ -50,11 +54,29 @@ class AuthController {
         });
       }
       const userData = addTokenToRes(user);
-      res.cookie('token', userData.token, { maxAge: 7200000, httpOnly: true });
+      res.cookie('token', userData.token, {
+        maxAge: 7200000,
+        httpOnly: true,
+        sameSite: true
+      });
       successResponse(res, userData, 200);
     } catch (e) {
       errorResponse(res, {});
     }
+  }
+
+  /**
+   *  Logs out an autheticated user.
+   * @static
+   * @param {Request} req - The request from the endpoint.
+   * @param {Response} res - The response returned by the method.
+   * @returns { JSON } - A JSON object containing success or failure details.
+   * @memberof Auth
+   */
+  static logout(req, res) {
+    res.clearCookie('token', { httpOnly: true, sameSite: true });
+    const data = { message: 'You have been successfully logged out' };
+    successResponse(res, data, 200);
   }
 }
 

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,5 +1,6 @@
 import AuthController from './auth';
 import QuestionController from './question';
 import AnswerController from './answer';
+import UserController from './user';
 
-export { AuthController, QuestionController, AnswerController };
+export { AuthController, QuestionController, AnswerController, UserController };

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -1,0 +1,49 @@
+import Helpers from '../utils';
+import { User } from '../services';
+
+const { successResponse, errorResponse, getQuery } = Helpers;
+const { fetch } = User;
+
+/**
+ * A collection of methods that controls the success response
+ * for CRUD operations on a User Instance.
+ *
+ * @class UserController
+ */
+class UserController {
+  /**
+   * Fetches atleast 30 questions.
+   *
+   * @static
+   * @param {Request} req - The request from the endpoint.
+   * @param {Response} res - The response returned by the method.
+   * @returns { JSON } A JSON response containing the details of the question.
+   * @memberof QuestionController
+   */
+  static async getUsers(req, res) {
+    try {
+      const { page, limit } = req.query;
+      const filter = getQuery(req.query);
+      const users = await fetch({ page, limit, filter });
+      successResponse(res, users, 200);
+    } catch (e) {
+      errorResponse(res, {});
+    }
+  }
+
+  /**
+   * Returns the a user object with the id in the path variable.
+   *
+   * @static
+   * @param {Request} req - The request from the endpoint.
+   * @param {Response} res - The response returned by the method.
+   * @returns { JSON } A JSON response containing the details of the user.
+   * @memberof UserController
+   */
+  static async getUser(req, res) {
+    const { user } = req;
+    successResponse(res, user, 200);
+  }
+}
+
+export default UserController;

--- a/src/middlewares/answerMiddleware.js
+++ b/src/middlewares/answerMiddleware.js
@@ -1,0 +1,48 @@
+import Helpers from '../utils';
+import { Answer } from '../services';
+
+const { fetchById } = Answer;
+const { errorResponse } = Helpers;
+
+/**
+ * A collection of middleware methods used to verify the autheticity
+ * of a request for an answer through the Answer route.
+ *
+ * @class AnswerMiddleware
+ */
+class AnswerMiddleware {
+  /**
+   * Checks that the id in the path belongs to an existing answer.
+   * @param {object} req - The request from the endpoint.
+   * @param {object} res - The response returned by the method.
+   * @param {function} next - Call the next operation.
+   *@returns {object} - Returns an object (error or response).
+   * @memberof AnswerMiddleware
+   *
+   */
+  static async validateId(req, res, next) {
+    const { id } = req.params;
+    try {
+      const answer = await fetchById(id);
+      if (!answer) {
+        return errorResponse(res, {
+          code: 404,
+          message: 'An answer with the id provided was not found'
+        });
+      }
+      req.answer = answer;
+      next();
+    } catch (e) {
+      const regex = /Cast to ObjectId/i;
+      if (regex.test(e.message)) {
+        return errorResponse(res, {
+          code: 400,
+          message: 'Invalid answer Id'
+        });
+      }
+      errorResponse(res, {});
+    }
+  }
+}
+
+export default AnswerMiddleware;

--- a/src/middlewares/index.js
+++ b/src/middlewares/index.js
@@ -1,4 +1,6 @@
 import AuthMiddleware from './authMiddleware';
 import QuestionMiddleware from './questionMiddleware';
+import AnswerMiddleware from './answerMiddleware';
+import UserMiddleware from './userMiddleware';
 
-export { AuthMiddleware, QuestionMiddleware };
+export { AuthMiddleware, QuestionMiddleware, AnswerMiddleware, UserMiddleware };

--- a/src/middlewares/userMiddleware.js
+++ b/src/middlewares/userMiddleware.js
@@ -1,0 +1,48 @@
+import Helpers from '../utils';
+import { User } from '../services';
+
+const { fetchById } = User;
+const { errorResponse } = Helpers;
+
+/**
+ * A collection of middleware methods used to verify the autheticity
+ * of a request for an user's account through the user route.
+ *
+ * @class UserMiddleware
+ */
+class UserMiddleware {
+  /**
+   * Checks that the id in the path belongs to an existing answer.
+   * @param {object} req - The request from the endpoint.
+   * @param {object} res - The response returned by the method.
+   * @param {function} next - Call the next operation.
+   *@returns {object} - Returns an object (error or response).
+   * @memberof UserMiddleware
+   *
+   */
+  static async validateId(req, res, next) {
+    const { id } = req.params;
+    try {
+      const user = await fetchById(id);
+      if (!user) {
+        return errorResponse(res, {
+          code: 404,
+          message: 'A user with the id provided was not found'
+        });
+      }
+      req.user = user;
+      next();
+    } catch (e) {
+      const regex = /Cast to ObjectId/i;
+      if (regex.test(e.message)) {
+        return errorResponse(res, {
+          code: 400,
+          message: 'Invalid user Id'
+        });
+      }
+      errorResponse(res, {});
+    }
+  }
+}
+
+export default UserMiddleware;

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -33,7 +33,7 @@ const userSchema = new Schema(
   },
   options
 );
-userSchema.index({ firstName: 'text' });
+
 const User = mongoose.model('User', userSchema);
 
 export default User;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,10 +2,14 @@ import swaggerUI from 'swagger-ui-express';
 import apiDocs from '../../swagger.json';
 import authRoutes from './v1/auth';
 import questionRoutes from './v1/question';
+import answerRoutes from './v1/answer';
+import userRoutes from './v1/user';
 
 const routes = app => {
   app.use('/api/v1/auth', authRoutes);
+  app.use('/api/v1/user', userRoutes);
   app.use('/api/v1/question', questionRoutes);
+  app.use('/api/v1/answer', answerRoutes);
   app.use('/api/v1/docs', swaggerUI.serve, swaggerUI.setup(apiDocs));
 };
 

--- a/src/routes/v1/answer.js
+++ b/src/routes/v1/answer.js
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { AnswerMiddleware } from '../../middlewares';
+import { AnswerController } from '../../controllers';
+
+const { validateId } = AnswerMiddleware;
+const { getAnswerById } = AnswerController;
+
+const router = Router();
+
+router.get('/:id', validateId, getAnswerById);
+
+export default router;

--- a/src/routes/v1/auth.js
+++ b/src/routes/v1/auth.js
@@ -2,9 +2,10 @@ import { Router } from 'express';
 import { AuthMiddleware } from '../../middlewares';
 import { AuthController } from '../../controllers';
 
-const { signup, signin } = AuthController;
+const { signup, signin, logout } = AuthController;
 const {
   validate,
+  authenticate,
   checkEmailAlreadyExists,
   validateLoginFields,
   verifyIfExistingUser
@@ -14,5 +15,6 @@ const router = Router();
 
 router.post('/signup', validate, checkEmailAlreadyExists, signup);
 router.post('/signin', validateLoginFields, verifyIfExistingUser, signin);
+router.get('/logout', authenticate, logout);
 
 export default router;

--- a/src/routes/v1/user.js
+++ b/src/routes/v1/user.js
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { UserMiddleware } from '../../middlewares';
+import { UserController } from '../../controllers';
+
+const { validateId } = UserMiddleware;
+const { getUser, getUsers } = UserController;
+
+const router = Router();
+router.get('/', getUsers);
+router.get('/:id', validateId, getUser);
+
+export default router;

--- a/src/services/answer.js
+++ b/src/services/answer.js
@@ -38,6 +38,29 @@ class AnswerService extends Answer {
         select: '-__v -password -createdAt -updatedAt'
       });
   }
+
+  /**
+   * Finds a answer by its id.
+   * @param {string} id - The answer's id.
+   * @returns {Promise<object>} A promise object with search results.
+   * @memberof QuestionService
+   */
+  static async fetchById(id) {
+    return Answer.findById(id)
+      .select('-__v')
+      .populate({
+        path: 'question',
+        select: '-__v -upVote.by -downVote.by -answers',
+        populate: {
+          path: 'author',
+          select: 'firstName lastName email'
+        }
+      })
+      .populate({
+        path: 'author',
+        select: '-__v -password -createdAt -updatedAt'
+      });
+  }
 }
 
 export default AnswerService;

--- a/src/services/question.js
+++ b/src/services/question.js
@@ -1,6 +1,7 @@
 import { Question } from '../models';
 import User from './user';
 
+const { fetchByAuthorName } = User;
 /**
  * It is the interface for question model.
  *
@@ -61,21 +62,8 @@ class QuestionService extends Question {
    * @memberof QuestionService
    */
   static async fetchQuestionByAuthorName(authorName, skip, limit) {
-    const nameArr = authorName.split(' ');
-    let arrayOfIds;
-    let filter;
-    if (nameArr.length === 1) {
-      filter = { $text: { $search: nameArr[0] } };
-      arrayOfIds = await User.find(filter).select('_id');
-    } else {
-      filter = {
-        firstName: new RegExp(nameArr[0], 'i'),
-        lastName: new RegExp(nameArr[1], 'i')
-      };
-      arrayOfIds = await User.find(filter).select('_id');
-    }
-
-    const idArr = arrayOfIds.map(async ({ _id }) => _id);
+    const users = await fetchByAuthorName(authorName);
+    const idArr = users.map(async ({ _id }) => _id);
     const result = await Promise.all(idArr);
     return QuestionService.find({ author: { $in: [...result] } })
       .select('-__v')

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -1,5 +1,7 @@
 import { User } from '../models';
+import Helpers from '../utils';
 
+const { userFilterObj, checkFilter } = Helpers;
 /**
  * It is the interface of user model.
  *
@@ -10,11 +12,35 @@ class UserService extends User {
    * Finds a user with properties specified in the argument.
    * @param {number | object | string} options - An object containing properties to
    * be used as search criteria.
+   * @param {number} options.limit - Max number of records.
+   * @param {number} options.page - Current page e.g: 1 represents first
+   * 30 records by default and 2 represents the next 30 records .
+   * @param {object} options.filter - Search criteria.
    * @returns {Promise<object>} A promise object with user detail.
    * @memberof UserService
    */
   static async fetch(options = {}) {
-    return UserService.find(options).select('-__v -password');
+    const limit = +options.limit || 30;
+    const skip = +options.page ? (+options.page - 1) * limit : 0;
+    if (options.filter.name) {
+      const { name } = options.filter;
+      return UserService.fetchByAuthorName(name, skip, limit);
+    }
+    const filter = userFilterObj(options.filter) || {};
+    return UserService.find(checkFilter(filter))
+      .select('-__v -password')
+      .skip(skip)
+      .limit(limit);
+  }
+
+  /**
+   * Finds a user by his/her email
+   * @param {string} id - User's email address
+   * @returns {Promise<object>} A promise object with user detail.
+   * @memberof UserService
+   */
+  static async fetchById(id) {
+    return UserService.findById(id).select('-__v -password');
   }
 
   /**
@@ -29,19 +55,27 @@ class UserService extends User {
 
   /**
    * Finds a collection of users whose first names matches the search field
-   * @param {string} firstName - User's firstName
+   * @param {string} name - User's name.
+   * @param {number} skip - Offset value.
+   * @param {number} limit - Max number of records.
    * @returns {Promise<object>} A promise object with user detail.
    * @memberof UserService
    */
-  static async fetchByFirstName(firstName) {
-    return UserService.find(
-      { $text: { $search: firstName } },
-      { score: { $meta: 'textScore' } }
-    )
-      .sort({
-        score: { $meta: 'textScore' }
-      })
-      .select('-__v -password');
+  static async fetchByAuthorName(name, skip, limit = 0) {
+    const skipValue = skip || 0;
+    const nameArr = name.split(' ');
+    let filter;
+    if (nameArr.length === 1) filter = { firstName: new RegExp(nameArr[0], 'i') };
+    else {
+      filter = {
+        firstName: new RegExp(nameArr[0], 'i'),
+        lastName: new RegExp(nameArr[1], 'i')
+      };
+    }
+    return UserService.find(filter)
+      .select('-__v -password')
+      .skip(skipValue)
+      .limit(limit);
   }
 }
 

--- a/src/test/dummy.js
+++ b/src/test/dummy.js
@@ -58,3 +58,9 @@ export const mockRes = {
     return result;
   }
 };
+export const someNewDude = {
+  firstName: 'Muhammed',
+  lastName: 'Buhari',
+  email: 'presido@naija.com',
+  password: 'verytoughtocrack'
+};

--- a/src/test/user.test.js
+++ b/src/test/user.test.js
@@ -1,0 +1,88 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import app from '..';
+import { mockRes, someNewDude } from './dummy';
+import { AuthController } from '../controllers';
+
+const { signup } = AuthController;
+chai.use(chaiHttp);
+
+
+describe('User route Endpoints', () => {
+  const baseUrl = '/api/v1/user';
+  let userId;
+  before(async () => {
+    const req = { body: { ...someNewDude } };
+
+    const { data } = await signup(req, mockRes);
+    userId = data._id;
+  });
+  describe('GET /api/v1/user', () => {
+    it('it should retrieve all users with the max number of records set at 30', async () => {
+      const response = await chai.request(app).get(`${baseUrl}`);
+      const { data, status } = response.body;
+      expect(response).to.have.status(200);
+      expect(status).to.eql('success');
+      expect(data.length).to.be.at.most(30);
+      expect(data.length).to.be.at.least(1);
+    });
+    it('should enable users to search for a user by firstname', async () => {
+      const response = await chai.request(app).get(`${baseUrl}?name=ayo`);
+      const { data, status } = response.body;
+      expect(response).to.have.status(200);
+      expect(status).to.eql('success');
+      expect(data.length).to.eql(3);
+    });
+    it('should enable users to search for a user by fullname', async () => {
+      const response = await chai.request(app).get(`${baseUrl}?name=ayodele Aki`);
+      const { data, status } = response.body;
+      expect(response).to.have.status(200);
+      expect(status).to.eql('success');
+      expect(data.length).to.eql(1);
+    });
+    it('should allow users to search for users by a generic property using key and value as query parameters', async () => {
+      const response = await chai
+        .request(app)
+        .get(`${baseUrl}?key=email&value=daylay10@yahoo.com`);
+      const { data, status } = response.body;
+      expect(response).to.have.status(200);
+      expect(status).to.eql('success');
+      expect(data.length).to.eql(1);
+    });
+    it('it should ignore the password field if it is set as a query parameter', async () => {
+      const response = await chai
+        .request(app)
+        .get(`${baseUrl}?value=ayodele&key=password`);
+      const { data, status } = response.body;
+      expect(response).to.have.status(200);
+      expect(status).to.eql('success');
+      expect(data.length).to.eql(4);
+    });
+  });
+  describe('GET api/v1/user/:userId', () => {
+    it('should allow users to fetch a single user by his/her id', async () => {
+      const response = await chai.request(app).get(`${baseUrl}/${userId}`);
+      const { data, status } = response.body;
+      expect(response).to.have.status(200);
+      expect(status).to.eql('success');
+      delete someNewDude.password;
+      expect(data).to.include(someNewDude);
+    });
+    it("should return a 404 error if a user with the id specified doesn't exist", async () => {
+      const response = await chai
+        .request(app)
+        .get(`${baseUrl}/5d9e147c06a21a2180dfb976`);
+      const { error, status } = response.body;
+      expect(response).to.have.status(404);
+      expect(status).to.eql('fail');
+      expect(error.message).to.eql('A user with the id provided was not found');
+    });
+    it('should return an error message if the route path contains an invalid id variable', async () => {
+      const response = await chai.request(app).get(`${baseUrl}/5`);
+      const { error, status } = response.body;
+      expect(response).to.have.status(400);
+      expect(status).to.eql('fail');
+      expect(error.message).to.eql('Invalid user Id');
+    });
+  });
+});

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -163,6 +163,35 @@ class Helpers {
   }
 
   /**
+   * Builds filter object for searching for users.
+   * @static
+   * @param {object} queryObj - Express Query Object.
+   * @memberof Helpers
+   * @returns {object } - A javascript object.
+   */
+  static userFilterObj(queryObj) {
+    const res = { ...queryObj };
+    if (res.key && res.value) {
+      const { key, value } = res;
+      return { [key]: value };
+    }
+    return res;
+  }
+
+  /**
+   * Checks if the filter object contains a password field and returns an empty object if it does.
+   * @static
+   * @param {object} filter - The user filter object.
+   * @memberof Helpers
+   * @returns {object } - A javascript object.
+   */
+  static checkFilter(filter) {
+    const res = { ...filter };
+    if (res.password) return {};
+    return res;
+  }
+
+  /**
    * Builds filter object for searching for questions.
    * @static
    * @param {object} queryObj - Express Query Object.

--- a/swagger.json
+++ b/swagger.json
@@ -35,6 +35,10 @@
       "description": "Endpoints for Authentication"
     },
     {
+      "name": "User",
+      "description": "Endpoints for Users"
+    },
+    {
       "name": "Question",
       "description": "Endpoints for Questions"
     },
@@ -123,6 +127,140 @@
             "description": "Unautheticated Request / Invalid login credentials",
             "schema": {
               "$ref": "#/components/schemas/responseBody/401"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/components/schemas/responseBody/500"
+            }
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "get": {
+        "description": "Logs out a user",
+        "summary": "Enables a user to logout",
+        "tags": ["Auth"],
+        "produces": ["application/json"],
+        "security": [],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successfully logged out a user.",
+            "schema": {
+              "$ref": "#/components/schemas/responseBody/logoutSuccess"
+            }
+          },
+          "401": {
+            "description": "You are not logged in",
+            "schema": {
+              "$ref": "#/components/schemas/responseBody/401"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/components/schemas/responseBody/500"
+            }
+          }
+        }
+      }
+    },
+    "/user": {
+      "get": {
+        "description": "Retrieves a collection of users based on the query parameters",
+        "summary": "Enables all users to view other user's details and to filter results based on query parameters with the option paginating and setting a limit to the number of users retrieved",
+        "tags": ["Search"],
+        "produces": ["application/json"],
+        "security": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "description": "The author's firstname or full name"
+          },
+          {
+            "in": "query",
+            "name": "key",
+            "required": false,
+            "description": "Any generic property of a user, like email or id, password field is ignored"
+          },
+          {
+            "in": "query",
+            "name": "value",
+            "required": false,
+            "description": "The value of the key. e.g: if key is email then value could be wer@hot.com"
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "description": "The maximum number of questions to be retrieved"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "description": "It is the unit used to determine an offset value, as an example; a limit of 2 and a page value of 2 would offset the collection of questions by 2 and return 2 records"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved users",
+            "schema": {
+              "$ref": "#/components/schemas/responseBody/200"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/components/schemas/responseBody/500"
+            }
+          }
+        }
+      }
+    },
+    "/user/{id}": {
+      "get": {
+        "description": "Retrieves a single user",
+        "summary": "Retrieves a user by Id",
+        "tags": ["User"],
+        "produces": ["application/json"],
+        "security": [],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "description": "The user's Id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved user",
+            "schema": {
+              "$ref": "#/components/schemas/responseBody/200"
+            }
+          },
+          "400": {
+            "description": "Invalid user Id",
+            "schema": {
+              "$ref": "#/components/schemas/responseBody/400"
+            }
+          },
+          "401": {
+            "description": "Unautheticated Request / Invalid login credentials",
+            "schema": {
+              "$ref": "#/components/schemas/responseBody/401"
+            }
+          },
+          "404": {
+            "description": "A user with the id doesn't exist",
+            "schema": {
+              "$ref": "#/components/schemas/responseBody/404"
             }
           },
           "500": {
@@ -404,6 +542,49 @@
           },
           "404": {
             "description": "A question with the id doesn't exist",
+            "schema": {
+              "$ref": "#/components/schemas/responseBody/404"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/components/schemas/responseBody/500"
+            }
+          }
+        }
+      }
+    },
+    "/answer/{id}": {
+      "get": {
+        "description": "Enables users to fetch an answer",
+        "summary": "Enables users to fetch an answer to a question by its Id",
+        "tags": ["Answer"],
+        "produces": ["application/json"],
+        "security": [],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "description": "The answer Id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved an answer to a question",
+            "schema": {
+              "$ref": "#/components/schemas/responseBody/answerSuccess"
+            }
+          },
+          "400": {
+            "description": "Invalid answer Id",
+            "schema": {
+              "$ref": "#/components/schemas/responseBody/400"
+            }
+          },
+          "404": {
+            "description": "An answer with the id doesn't exist",
             "schema": {
               "$ref": "#/components/schemas/responseBody/404"
             }
@@ -771,6 +952,24 @@
               },
               "createdAt": "2019-10-10T11:34:42.363Z",
               "updatedAt": "2019-10-10T11:51:12.381Z"
+            }
+          }
+        },
+        "logoutSuccess": {
+          "properties": {
+            "status": {
+              "description": "successful",
+              "type": "string"
+            },
+            "data": {
+              "description": "An object containing properties of the newly created record",
+              "type": "object"
+            }
+          },
+          "example": {
+            "status": "success",
+            "data": {
+              "message": "You have been successfully logged out"
             }
           }
         },


### PR DESCRIPTION
#### What does this PR do?
- Enables users to search for other users by their names.
- Enables users to search for other users by a generic user field like id, email, firstName or lastName by using `key` and `value` as query parameters and setting a field and its appropriate value as key and value respectively.
- Enables users to retrieve a user's details by his/her Id.
- Enables users to fetch an answer by its Id.
- Enables users to logout from the App.
#### Description of Task to be completed?
- Remove indexing from the firstName field of the User Model to enable partial text search for a user's name.
- Modify the User service's methods; `fetch`  to accommodate dynamic search.
- Implement helper methods for creating search filters.
- Implement method for fetching single and multiple users in the User controller.
- Create and Implement middleware for both the User and the Answer prototype.
- Implement logout method in the auth controller class.
- Add routes to facilitate the above mentioned.
- Add the route descriptions to the openAPI documentation.
- Write unit tests.
#### How should this be manually tested?
- Clone the repo and cd into the project folder
- Checkout to `ft-search-user` branch and run `npm install`.
- Add a `.env` file to the root directory and include in it the following environment variables;
```
 MONGO_DEV_URI=your mongodb connection string for development
MONGO_URI=your mongodb connection string for the test environment
SECRET=whateveryoulike
```
- Start the dev server by running `npm run start:dev`
- Using postman or insomnia, make a get request to `localhost:3000/api/v1/user?name={name of author}`
- To use the key-value search feature make a request like so; `localhost:3000/api/v1/user?key={email}&value={the user email address}`. You can try any other generic field but do note that the password field would be ignored.
- To search for a user by his/her Id, make a request to `localhost:3000/api/v1/user/{userId}`, passing the user's id as `{userId}`.
- To logout fire up a get request to `localhost:3000/api/v1/auth/logout`. 
- You can also fetch an answer by its id by making a request to  `localhost:3000/api/v1/answer/{answerId}`.
- You can also launch the api docs on your browser via `http://localhost:3000/api/v1/docs` for a head start.
- You can run `npm test` to see the results of the unit tests.
